### PR TITLE
prepared Darwin universal release and fix #10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,19 +2,9 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/**'
-      - '**.go'
-      - 'Makefile'
-      - 'go.**'
+    branches: [ main ]
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - '**.go'
-      - 'Makefile'
-      - 'go.**'
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
   push:
     tags:
       - 'v*'
-  pull_request:
-    paths:
-    - '.github/workflows/release.yml'
-    - '.goreleaser.yaml'
 
 jobs:
   goreleaser:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,9 +34,14 @@ builds:
   - darwin
   goarch:
     - amd64
+    - arm64
   ignore:
   - goos: darwin
     goarch: 386
+# https://goreleaser.com/customization/universalbinaries/?h=universal_binaries
+universal_binaries:
+  - replace: true
+    id: darwin-build
 archives:
   - id: linux-build
     format: binary
@@ -47,7 +52,7 @@ archives:
     format: binary
     builds:
       - darwin-build
-    name_template: "{{ .ProjectName }}_Darwin_x86_64"
+    name_template: "{{ .ProjectName }}_Darwin_all"
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Publish `envd-lsp_Darwin_all` for universal MacOS release, contains both `amd64` and `arm64`.
close #10 
close #30

Breaking change:
We would use `envd-lsp_Darwin_all` instead of `envd-lsp_Darwin_x86_64` since VSCode extension `v0.0.5`.

Example Release:
https://github.com/cutecutecat/envd-lsp/releases/tag/v1.0.0

About universal binary:
https://goreleaser.com/customization/universalbinaries/?h=universal_binaries

Signed-off-by: cutecutecat <starkind1997@gmail.com>