### PR TITLE
fix: semantic token request not worked

### DIFF
--- a/pkg/lsp/fixture_test.go
+++ b/pkg/lsp/fixture_test.go
@@ -36,11 +36,12 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/tilt-dev/starlark-lsp/pkg/analysis"
+	"github.com/tensorchord/envd-lsp/pkg/analysis"
+	"github.com/tensorchord/envd-lsp/pkg/api"
+	"github.com/tensorchord/envd-lsp/pkg/server"
 	"github.com/tilt-dev/starlark-lsp/pkg/document"
 	"github.com/tilt-dev/starlark-lsp/pkg/middleware"
 	"github.com/tilt-dev/starlark-lsp/pkg/query"
-	"github.com/tilt-dev/starlark-lsp/pkg/server"
 )
 
 type fixture struct {
@@ -51,8 +52,9 @@ type fixture struct {
 	editorEvents chan jsonrpc2.Request
 }
 
-func mockAnalyzer(ctx context.Context, api string) *analysis.Analyzer {
-	stubs := ApiVersionStubs(api)()
+func mockAnalyzer(ctx context.Context, apiPick string) *analysis.Analyzer {
+	apiVersion := api.APIOptions[apiPick]
+	stubs := ApiVersionStubs(apiVersion)()
 	opts := []analysis.AnalyzerOption{
 		analysis.WithStarlarkBuiltins(), analysis.WithBuiltins(stubs),
 	}

--- a/pkg/lsp/lsp_test.go
+++ b/pkg/lsp/lsp_test.go
@@ -49,24 +49,24 @@ func TestLSP_Hover(t *testing.T) {
 
 }
 
-func TestLSP_Hover_Bad_API(t *testing.T) {
-	f := newFixture(t, "bad-api")
+func TestServer_SemanticToken(t *testing.T) {
+	f := newFixture(t, "stable")
 
-	docURI := uri.File("./bad-api.envd")
-	doc := `base(os="ubuntu20.04", language="python3")`
+	docURI := uri.File("./semantic.star")
+	doc := `
+def build():
+	pass
+def build_GPU():
+	pass
+`
 
-	f.mustWriteDocument("./bad-api.envd", doc)
+	f.mustWriteDocument("./semantic.star", doc)
 
-	var resp protocol.Hover
-	f.mustEditorCall(protocol.MethodTextDocumentHover, protocol.HoverParams{
-		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
-			Position: protocol.Position{
-				Line:      0,
-				Character: 0,
-			},
-		},
+	var resp protocol.SemanticTokens
+
+	f.mustEditorCall(protocol.MethodSemanticTokensFull, protocol.SemanticTokensParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
 	}, &resp)
 
-	require.Empty(t, resp.Contents.Value)
+	require.Len(t, resp.Data, 10)
 }

--- a/pkg/lsp/lsp_test.go
+++ b/pkg/lsp/lsp_test.go
@@ -52,7 +52,7 @@ func TestLSP_Hover(t *testing.T) {
 func TestServer_SemanticToken(t *testing.T) {
 	f := newFixture(t, "stable")
 
-	docURI := uri.File("./semantic.star")
+	docURI := uri.File("./semantic.envd")
 	doc := `
 def build():
 	pass
@@ -60,7 +60,7 @@ def build_GPU():
 	pass
 `
 
-	f.mustWriteDocument("./semantic.star", doc)
+	f.mustWriteDocument("./semantic.envd", doc)
 
 	var resp protocol.SemanticTokens
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,7 +18,9 @@ import (
 
 	"github.com/tensorchord/envd-lsp/pkg/analysis"
 	"github.com/tilt-dev/starlark-lsp/pkg/document"
+	"github.com/tilt-dev/starlark-lsp/pkg/middleware"
 	starlark_server "github.com/tilt-dev/starlark-lsp/pkg/server"
+	"go.lsp.dev/jsonrpc2"
 	"go.lsp.dev/protocol"
 )
 
@@ -36,4 +38,10 @@ func NewServer(cancel context.CancelFunc, notifier protocol.Client, docManager *
 		docs:     docManager,
 		analyzer: analyzer,
 	}
+}
+
+// Overwrite starlark-lsp handler
+func (s *Server) Handler(middlewares ...middleware.Middleware) jsonrpc2.Handler {
+	serverHandler := protocol.ServerHandler(s, jsonrpc2.MethodNotFoundHandler)
+	return middleware.WrapHandler(serverHandler, middlewares...)
 }


### PR DESCRIPTION
In previous deploy, though own `server`  is deployed instead of `starlark-lsp server`, we need to implement `Handle` either, or default `starlark-lsp Handler()` will register `starlark-lsp server` to LSP protocol.

In that case, our new `semantic token` request will fallback to starlark-lsp and turn to undefined.
```
[Error  - 2:46:22 PM] [LSP] LSP SemanticTokens Request failed: Error: JSON-RPC method not found
```

Works:
- overwrite the server handler to fix
- add e2e test for semantic token request
- substitute e2e test from starlark-lsp server to envd-lsp server

Signed-off-by: cutecutecat <starkind1997@gmail.com>