### PR TITLE
fix: build error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+env:
+  GOLANG_VERSION: '1.20'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version:  ${{ env.GOLANG_VERSION }}
       - uses: actions/checkout@v3
       - name: Cache Go modules
         uses: actions/cache@preview
@@ -47,7 +49,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46.2
+          version: v1.52.2
   test:
     name: test
     strategy:
@@ -67,7 +69,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: ${{ env.GOLANG_VERSION }}
       - name: Cache Go modules
         uses: actions/cache@preview
         with:
@@ -98,7 +100,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: ${{ env.GOLANG_VERSION }}
       - name: Cache Go modules
         uses: actions/cache@preview
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: release
 
 on:
   workflow_call:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
   push:
     tags:
       - 'v*'
@@ -17,10 +19,6 @@ jobs:
           fetch-depth: 0
       - name: Show tags
         run: git tag
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.18
       - name: setup release environment
         run: |-
           echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ export SHELL := bash
 export SHELLOPTS := errexit
 
 PACKAGE_NAME := github.com/tensorchord/envd-lsp
-GOLANG_CROSS_VERSION  ?= v1.17.6
+GOLANG_CROSS_VERSION  ?= v1.20.4
 
 # Project main package location (can be multiple ones).
 CMD_DIR := ./cmd

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tensorchord/envd-lsp
 
-go 1.18
+go 1.20
 
 require (
 	github.com/cockroachdb/errors v1.9.1


### PR DESCRIPTION
Fix CICD build error by updating Golang toolchain to `1.20`.
# Before
https://github.com/tensorchord/envd-lsp/actions/runs/5078645877
# After
https://github.com/cutecutecat/envd-lsp/actions/runs/5088077850/jobs/9144071456